### PR TITLE
Updated torch-log-wmse repo reference.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ log_wmse = calculate_log_wmse(input_sound, est_sound, target_sound, sample_rate)
 print(log_wmse)  # Expected output: ~18.42
 ```
 
-If you need a pytorch implementation of logWMSE, see [crlandsc/torch-log-wmse-audio-quality](https://github.com/crlandsc/torch-log-wmse-audio-quality)
+If you need a pytorch implementation of logWMSE, see [crlandsc/torch-log-wmse](https://github.com/crlandsc/torch-log-wmse)
 
 # Motivation and more info
 


### PR DESCRIPTION
I changed the name of the torch implementation to `torch-log-wmse` for simplicity. It can be pip installed as both `torch-log-wmse-audio-quality` and `torch-log-wmse`, but everything will be with reference to the shorter name moving forward.

Btw, I have had very good luck training with it so far and appears to improve all metrics (L1, L2, SISDR, Multires-STFT, Sum & Difference STFT, RMSE) as well as perceptual quality (based on my personal listeninig) compared to training with the standard L1 loss. I don't have any findings that I can officially report, as I have just been using it for our specific purpose, but it would follow that the performance gain should translate to generic music source separation.